### PR TITLE
Bump up Android Studio to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can develop UhooiPicBook-Android.
 
 ### Environment
 
-- Android Studio: 3.6.1
+- Android Studio: 4.0.0
 
 ### Configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 25 14:59:31 JST 2020
+#Sun Jul 12 13:12:14 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip


### PR DESCRIPTION
## Issue 
- close #38 

## Overview
- Bump up Android Studio version to 4.0.
- Bump up gradle version to 6.5.1 too.   