### PR TITLE
[Proposal] Implemented DarkTheme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-firestore-ktx:21.4.3'
 
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.cardview:cardview:1.0.0'
 
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
@@ -79,6 +78,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+
+    implementation 'com.google.android.material:material:1.2.0'
 
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:runner:1.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
+        android:theme="@style/Theme.UhooiPickBook"
         android:fullBackupContent="@xml/backup_descriptor">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.UhooiPickBook"
+        android:theme="@style/Theme.UhooiPicBook"
         android:fullBackupContent="@xml/backup_descriptor">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/app/src/main/java/com/theuhooi/uhooipicbook/MainActivity.kt
+++ b/app/src/main/java/com/theuhooi/uhooipicbook/MainActivity.kt
@@ -4,10 +4,10 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
+import com.google.android.material.color.MaterialColors
 import com.theuhooi.uhooipicbook.extensions.IntColorInterface
 import com.theuhooi.uhooipicbook.modules.monsterlist.MonsterListFragment
 import com.theuhooi.uhooipicbook.modules.monsterlist.MonsterListFragmentDirections
@@ -37,10 +37,20 @@ class MainActivity : AppCompatActivity(), MonsterListFragment.OnListFragmentInte
         val navController = findNavController(R.id.nav_host_fragment)
         navController.addOnDestinationChangedListener { _, destination, _ ->
             if (destination.id == R.id.monster_list_fragment) {
-                this.supportActionBar?.setBackgroundDrawable(
-                    ColorDrawable(ContextCompat.getColor(this, R.color.colorPrimary))
+                supportActionBar?.setBackgroundDrawable(
+                    ColorDrawable(
+                        MaterialColors.getColor(
+                            this,
+                            R.attr.colorPrimary,
+                            "colorPrimary is not set in the current theme"
+                        )
+                    )
                 )
-                this.window.statusBarColor = ContextCompat.getColor(this, R.color.colorPrimaryDark)
+                window.statusBarColor = MaterialColors.getColor(
+                    this,
+                    R.attr.colorPrimaryVariant,
+                    "colorPrimaryVariant is not set in the current theme"
+                )
             }
         }
         val appBarConfiguration = AppBarConfiguration(navController.graph)

--- a/app/src/main/java/com/theuhooi/uhooipicbook/MainActivity.kt
+++ b/app/src/main/java/com/theuhooi/uhooipicbook/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : AppCompatActivity(), MonsterListFragment.OnListFragmentInte
         val navController = findNavController(R.id.nav_host_fragment)
         navController.addOnDestinationChangedListener { _, destination, _ ->
             if (destination.id == R.id.monster_list_fragment) {
-                supportActionBar?.setBackgroundDrawable(
+                this.supportActionBar?.setBackgroundDrawable(
                     ColorDrawable(
                         MaterialColors.getColor(
                             this,
@@ -46,7 +46,7 @@ class MainActivity : AppCompatActivity(), MonsterListFragment.OnListFragmentInte
                         )
                     )
                 )
-                window.statusBarColor = MaterialColors.getColor(
+                this.window.statusBarColor = MaterialColors.getColor(
                     this,
                     R.attr.colorPrimaryVariant,
                     "colorPrimaryVariant is not set in the current theme"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,14 +6,11 @@
     android:layout_height="fill_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="@dimen/toolbar_elevation"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+        android:layout_height="?attr/actionBarSize" />
 
     <fragment
         android:id="@+id/nav_host_fragment"

--- a/app/src/main/res/layout/fragment_monster_detail.xml
+++ b/app/src/main/res/layout/fragment_monster_detail.xml
@@ -22,7 +22,7 @@
         android:layout_marginTop="32dp"
         android:text="@string/name_dummy"
         android:textAlignment="center"
-        android:textColor="@android:color/black"
+        android:textColor="?android:attr/textColorPrimary"
         android:textSize="36sp"
         android:textStyle="bold" />
 
@@ -34,7 +34,7 @@
         android:layout_marginTop="64dp"
         android:text="@string/description_dummy"
         android:textAlignment="center"
-        android:textColor="@android:color/darker_gray"
+        android:textColor="?android:attr/textColorSecondary"
         android:textSize="16sp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_monster_detail.xml
+++ b/app/src/main/res/layout/fragment_monster_detail.xml
@@ -12,7 +12,7 @@
         android:layout_height="240dp"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="56dp"
-        android:contentDescription="@string/icon_content_description" />
+        android:contentDescription="@string/icon_description" />
 
     <TextView
         android:id="@+id/name_textview"

--- a/app/src/main/res/layout/item_monster_list.xml
+++ b/app/src/main/res/layout/item_monster_list.xml
@@ -9,12 +9,11 @@
             type="com.theuhooi.uhooipicbook.modules.monsterlist.entities.MonsterItem" />
     </data>
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/card_margin"
-        android:foreground="?android:attr/selectableItemBackground"
         app:cardElevation="@dimen/card_elevation">
 
         <LinearLayout
@@ -39,9 +38,9 @@
                 android:layout_margin="@dimen/text_margin"
                 android:text="@{monsterItem.name, default=@string/name_dummy}"
                 android:textAppearance="?attr/textAppearanceListItem"
-                android:textColor="@android:color/black"
+                android:textColor="?attr/colorOnSurface"
                 android:textSize="24sp"
                 android:textStyle="bold" />
         </LinearLayout>
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 </layout>

--- a/app/src/main/res/layout/item_monster_list.xml
+++ b/app/src/main/res/layout/item_monster_list.xml
@@ -27,7 +27,7 @@
                 android:layout_width="68dp"
                 android:layout_height="68dp"
                 android:layout_margin="16dp"
-                android:contentDescription="@string/icon_content_description"
+                android:contentDescription="@string/icon_description"
                 app:imageUrl="@{monsterItem.iconUrlString}"/>
 
             <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,5 +3,4 @@
     <color name="colorPrimary">#81D674</color>
     <color name="colorPrimaryDark">#64C746</color>
     <color name="colorAccent">#03DAC5</color>
-    <color name="textColorPrimary">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,5 @@
     <dimen name="start_padding">16dp</dimen>
     <dimen name="end_padding">16dp</dimen>
 
-    <dimen name="toolbar_elevation">4dp</dimen>
     <dimen name="card_elevation">1dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">UhooiPicBook</string>
-    <string name="icon_content_description">Icon</string>
+    <string name="icon_description">Icon</string>
 
     <string name="name_dummy">uhooi</string>
     <string name="description_dummy">ゆかいな　みどりの　せいぶつ。\nわるそうに　みえるが　むがい。</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!--
         Define widget styles
-        ex. <style name="Widget.UhooiPickBook.Toolbar" />
+        ex. <style name="Widget.UhooiPicBook.Toolbar" />
     -->
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,10 +1,6 @@
 <resources>
-
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:textColorPrimary">@color/textColorPrimary</item>
-    </style>
-
+    <!--
+        Define widget styles
+        ex. <style name="Widget.UhooiPickBook.Toolbar" />
+    -->
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.UhooiPickBook" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
+        <item name="colorSecondary">@color/colorAccent</item>
+        <item name="colorSecondaryVariant">@color/colorAccent</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.UhooiPickBook" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.UhooiPicBook" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
         <item name="colorSecondary">@color/colorAccent</item>


### PR DESCRIPTION
## Overview
- Implemented Dark Theme with reference to Dark Mode of iOS application.  
- Supports Dark Theme on Android 10 or later.

## Unimplemented
### Support Android 9 or earlier
- If you want to use Dark Theme on Android 9 or earlier, need to implement switch between Light and Dark Theme.
ref : https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#changing_themes_in-app

### Toolbar is too bright
- The color of Toolbar doesn't follow the Material Design guideline because I referred to iOS application.
ref : https://material.io/design/color/dark-theme.html#ui-application
> In a dark theme, the surface of the top app bar uses a dark color instead of a primary or secondary color.

## Issue
- #8 

## Screenshot

|Before|After(Light)|After(Dark)|
|:--:|:--:|:--:|
| ![device-2020-08-07-233832](https://user-images.githubusercontent.com/13705006/89656854-25c6b780-d907-11ea-816a-9892726db60b.png) | ![device-2020-08-07-233634](https://user-images.githubusercontent.com/13705006/89656758-fe6fea80-d906-11ea-8058-9f7183597834.png) | ![device-2020-08-07-233605](https://user-images.githubusercontent.com/13705006/89656751-fa43cd00-d906-11ea-97e3-59b4b9854309.png) |
| ![device-2020-08-07-233839](https://user-images.githubusercontent.com/13705006/89656866-28c1a800-d907-11ea-803e-9ba6f08e41a0.png) | ![device-2020-08-07-233643](https://user-images.githubusercontent.com/13705006/89656760-ff088100-d906-11ea-8270-a70e499b3e76.png) | ![device-2020-08-07-233620](https://user-images.githubusercontent.com/13705006/89656756-fdd75400-d906-11ea-9815-338da9f64bd9.png) |

