### PR TITLE
Remove MagicNumber rule for detekt #78

### DIFF
--- a/app/config/detekt/detekt.yml
+++ b/app/config/detekt/detekt.yml
@@ -24,3 +24,19 @@ processors:
   # - 'ClassCountProcessor'
   # - 'PackageCountProcessor'
   # - 'KtFileCountProcessor'
+
+style:
+  MagicNumber:
+    active: true
+    excludes: []
+    ignoreNumbers: []
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: true
+    ignoreLocalVariableDeclaration: true
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: true
+    ignoreNamedArgument: true
+    ignoreEnums: true
+    ignoreRanges: true
+


### PR DESCRIPTION
ref : https://detekt.github.io/detekt/style.html#configuration-options-10

![image](https://user-images.githubusercontent.com/34413373/105369787-3a450500-5c46-11eb-88a3-b462eccb00d3.png)

MagicNumberのstyle設定を行うことでMagicNumberルールを無視するようにできそうかと。