### PR TITLE
Setup Timber #80

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,8 @@ dependencies {
 
     implementation "com.google.android.gms:play-services-oss-licenses:17.0.0"
 
+    implementation 'com.jakewharton.timber:timber:4.7.1'
+
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'androidx.test:runner:1.3.0'
 

--- a/app/src/main/java/com/theuhooi/uhooipicbook/UhooiPicBookApp.kt
+++ b/app/src/main/java/com/theuhooi/uhooipicbook/UhooiPicBookApp.kt
@@ -12,6 +12,7 @@ import coil.decode.ImageDecoderDecoder
 import coil.util.CoilUtils
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.OkHttpClient
+import timber.log.Timber
 
 @HiltAndroidApp
 class UhooiPicBookApp : Application() {
@@ -20,6 +21,11 @@ class UhooiPicBookApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+
         createNotificationChannels()
         initializeCoilImageLoader()
     }


### PR DESCRIPTION
Timberでは、ReleaseビルドとDebugビルドで出力するログを切り分けられるのが大きなメリットかと思いました。
リリースログの場合、独自クラスを作る必要があったので、ReleaseLoggerクラスを作りました。

ApplicationクラスでTimberのセットアップをするのが一般的だとあったので、
MainApplicationクラスを作って、その中でTimberのセットアップをしています。

■デバックログ
　Timber.d("Debug messeage")
　Timberオブジェクトを使ってTimberのAPI（static関数）を呼び出します。

■リリースログ
　ReleaseLogger.initialize()
　ReleaseLogger.d("Release message")
　ReleaseLoggerクラスを初期化し、ReleaseLoggerクラスのstatic関数を呼び出します。

こんな感じでセットアップしてみました。