### PR TITLE
Updated environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can develop UhooiPicBook-Android.
 
 ### Environment
 
-- Android Studio: 4.0.0
+- Android Studio: 4.1.2
 
 ### Configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 12 13:12:14 JST 2020
+#Fri Jan 22 20:53:09 JST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip


### PR DESCRIPTION
## Overview
- Bump AGP version to 4.1.2.
- Bump gradle version to 6.8.

## Link
### AGP
- https://androidstudio.googleblog.com/2021/01/android-studio-412-available.html
- https://androidstudio.googleblog.com/2020/11/android-studio-411-available.html
- https://developer.android.com/studio/releases/#4-1-0

### gradle
- https://docs.gradle.org/6.8/release-notes.html
- https://docs.gradle.org/6.7.1/release-notes.html
- https://docs.gradle.org/6.7/release-notes.html
- https://docs.gradle.org/6.6.1/release-notes.html
- https://docs.gradle.org/6.6/release-notes.html