### PR TITLE
Show lint report on CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
     # 静的解析
     - name: Run Inspection
       run: ./gradlew lint
+      
+    # 結果の表示
+    - uses: yutailang0119/action-android-lint@v1
+      with:
+        xml_path: '**/build/reports/lint-results-*.xml'
 
     # アーティファクトへアップロード
     - name: Upload results Artifact


### PR DESCRIPTION
Show Errors and Warnings via Android Lint as Annotation on GitHub Actions.
Use [yutailang0119/action-android-lint](https://github.com/yutailang0119/action-android-lint) .

See example `Unchanged files with check annotations` in https://github.com/yutailang0119/UhooiPicBook-Android/pull/1/files