### PR TITLE
Bump AS from Chipmunk to Electric Eel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can develop this project.
 
 ### Environment
 
-- Android Studio: Chipmunk | 2021.2.1 Patch 2
+- Android Studio: Electric Eel | 2022.1.1 Patch 1
 
 ### Configuration
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,8 @@ android {
             versionNameSuffix = "-develop"
         }
     }
+
+    namespace = "com.theuhooi.uhooipicbook"
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.theuhooi.uhooipicbook">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 buildscript {
     val kotlinVersion by extra { "1.6.10" }
-    val navVersion by extra { "2.3.5" }
+    val navVersion by extra { "2.5.3" }
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.2")
+        classpath("com.android.tools.build:gradle:7.4.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
         // Safe Args

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
## Issue

- close #255

## Overview

Bump AS.

## Details (Optional)

- Bump AS from Chipmunk to Electric Eel
- Bump Gradle from `7.3.3` to `7.5`
- Bump AGP from `7.2.2` to `7.4.1`
- Bump Navigation from `2.3.5` to `2.5.3`

## Checklist

- [ ] Format code (<kbd>⌥⌘L</kbd> in Android Studio)
- [ ] Optimize imports (<kbd>^⌥O</kbd> in Android Studio)
- [ ] Resolve Android Studio warning

## Reference(s) (Optional)

### AGP

- https://developer.android.com/studio/releases/gradle-plugin

### Navigation

- https://developer.android.com/jetpack/androidx/releases/navigation#kts
