### PR TITLE
Bump libraries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,13 +13,13 @@ plugins {
 }
 
 android {
-    compileSdk = 31
+    compileSdk = 33
     buildToolsVersion = "33.0.2"
 
     defaultConfig {
         applicationId = "com.theuhooi.uhooipicbook"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 33
         versionCode = 7
         versionName = "1.6.0"
 
@@ -82,7 +82,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.7.0")
+    implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,7 +84,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("com.google.android.material:material:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.2")
 
     // Lifecycle

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,8 +89,8 @@ dependencies {
 
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
 
     val navVersion: String by rootProject
     implementation("androidx.navigation:navigation-ui-ktx:$navVersion")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 android {
     compileSdk = 31
-    buildToolsVersion = "30.0.3"
+    buildToolsVersion = "33.0.2"
 
     defaultConfig {
         applicationId = "com.theuhooi.uhooipicbook"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.2")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,8 +133,8 @@ dependencies {
     androidTestImplementation("com.squareup.leakcanary:leakcanary-android-instrumentation:$leakcanaryVersion")
 
     testImplementation("org.robolectric:robolectric:4.6.1")
-    testImplementation("androidx.test:runner:1.4.0")
-    testImplementation("androidx.test.ext:junit:1.1.3")
+    testImplementation("androidx.test:runner:1.5.2")
+    testImplementation("androidx.test.ext:junit:1.1.5")
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.4.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.2")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,7 +128,7 @@ dependencies {
     implementation("io.coil-kt:coil-gif:$coilVersion")
 
     // LeakCanary
-    val leakcanaryVersion = "2.7"
+    val leakcanaryVersion = "2.10"
     debugImplementation("com.squareup.leakcanary:leakcanary-android:$leakcanaryVersion")
     androidTestImplementation("com.squareup.leakcanary:leakcanary-android-instrumentation:$leakcanaryVersion")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
         classpath("com.google.firebase:perf-plugin:1.4.2")
 
         // OSS Licenses
-        classpath("com.google.android.gms:oss-licenses-plugin:0.10.5")
+        classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
         // Firebase
         classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.4")
-        classpath("com.google.firebase:perf-plugin:1.4.1")
+        classpath("com.google.firebase:perf-plugin:1.4.2")
 
         // OSS Licenses
         classpath("com.google.android.gms:oss-licenses-plugin:0.10.5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
 
         // Firebase
         classpath("com.google.gms:google-services:4.3.15")
-        classpath("com.google.firebase:firebase-crashlytics-gradle:2.8.1")
+        classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.4")
         classpath("com.google.firebase:perf-plugin:1.4.1")
 
         // OSS Licenses

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$navVersion")
 
         // Firebase
-        classpath("com.google.gms:google-services:4.3.10")
+        classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-crashlytics-gradle:2.8.1")
         classpath("com.google.firebase:perf-plugin:1.4.1")
 


### PR DESCRIPTION
## Overview

Bump libraries.

## Details (Optional)

- Bump buildToolsVersion from `30.0.3` to `33.0.2`
- Bump CompileSdk from `31` to `33`
- Bump TargetSdk from `31` to `33`
- Bump core-ktx from `1.7.0` to `1.9.0`
- Bump appcompat from `1.4.0` to `1.6.1`
- Bump material from `1.4.0` to `1.8.0`
- Bump constraintlayout from `2.1.2` to `2.1.4`
- Bump lifecycle-runtime-ktx from `2.4.0` to `2.5.1`
- Bump lifecycle-viewmodel-ktx from `2.4.0` to `2.5.1`
- Bump LeakCanary from `2.7` to `2.10`
- Bump androidx.test:runner from `1.4.0` to `1.5.2`
- Bump androidx.test.ext:junit from `1.1.3` to `1.1.5`
- Bump google-services from `4.3.10` to `4.3.15`
- Bump firebase-crashlytics-gradle from `2.8.1` to `2.9.4`
- Bump perf-plugin from `1.4.1` to `1.4.2`
- Bump oss-licenses-plugin from `0.10.5` to `0.10.6`

## Checklist

- [ ] Format code (<kbd>⌥⌘L</kbd> in Android Studio)
- [ ] Optimize imports (<kbd>^⌥O</kbd> in Android Studio)
- [ ] Resolve Android Studio warning

## Reference(s) (Optional)

### Build Tools

- https://developer.android.com/studio/releases/build-tools
