### PR TITLE
Bump Kotlin from 1.6.10 to 1.8.10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("kotlin-parcelize")
     kotlin("kapt")
     id("androidx.navigation.safeargs.kotlin")
-    id("com.google.dagger.hilt.android") version "2.41"
+    id("com.google.dagger.hilt.android") version "2.45"
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
     id("com.google.firebase.firebase-perf")
@@ -103,9 +103,9 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion")
 
-    val hiltVersion = "2.41"
+    val hiltVersion = "2.45"
     implementation("com.google.dagger:hilt-android:$hiltVersion")
-    kapt("com.google.dagger:hilt-android-compiler:$hiltVersion")
+    kapt("com.google.dagger:hilt-compiler:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-fragment:1.0.0")
 
     // Firebase

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.fragment:fragment-ktx:1.5.5")
 
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")

--- a/app/src/main/java/com/theuhooi/uhooipicbook/ui/monsterdetail/MonsterDetailFragment.kt
+++ b/app/src/main/java/com/theuhooi/uhooipicbook/ui/monsterdetail/MonsterDetailFragment.kt
@@ -10,12 +10,16 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import coil.ImageLoader
@@ -52,7 +56,27 @@ class MonsterDetailFragment : Fragment(R.layout.monster_detail_fragment), IntCol
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setHasOptionsMenu(true)
+        val menuHost: MenuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.monster_detail_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.share_menu_item -> {
+                        shareMonster()
+                        true
+                    }
+                    else -> false
+                }
+            }
+
+            override fun onMenuClosed(menu: Menu) {
+                super.onMenuClosed(menu)
+                disposable?.dispose()
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         val binding = MonsterDetailFragmentBinding.bind(view)
         binding.monster = monster
@@ -72,23 +96,6 @@ class MonsterDetailFragment : Fragment(R.layout.monster_detail_fragment), IntCol
             )
             activity.window.statusBarColor = actionBarColor.actionBarColorToStatusBarColor
         }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-
-        inflater.inflate(R.menu.monster_detail_menu, menu)
-        val shareMenuItem = menu.findItem(R.id.share_menu_item)
-        shareMenuItem.setOnMenuItemClickListener {
-            shareMonster()
-            true
-        }
-    }
-
-    override fun onDestroyOptionsMenu() {
-        super.onDestroyOptionsMenu()
-
-        disposable?.dispose()
     }
 
     // endregion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 buildscript {
-    val kotlinVersion by extra { "1.6.10" }
+    val kotlinVersion by extra { "1.8.10" }
     val navVersion by extra { "2.5.3" }
 
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.1")
+        classpath("com.android.tools.build:gradle:7.4.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
         // Safe Args


### PR DESCRIPTION
## Overview

Bump Kotlin.

## Details (Optional)

- Bump Kotlin from `1.6.10` to `1.8.10`
- Bump Hilt from `2.41` to `2.45`

## Checklist

- [ ] Format code (<kbd>⌥⌘L</kbd> in Android Studio)
- [ ] Optimize imports (<kbd>^⌥O</kbd> in Android Studio)
- [ ] Resolve Android Studio warning

## Reference(s) (Optional)

### Hilt

- https://github.com/google/dagger/releases
- https://dagger.dev/hilt/gradle-setup
- https://stackoverflow.com/questions/73302605/creationextras-must-have-a-value-by-saved-state-registry-owner-key

### Menu

- https://qiita.com/Nabe1216/items/b26b03cbc750ac70a842
- https://stackoverflow.com/questions/71917856/sethasoptionsmenuboolean-unit-is-deprecated-deprecated-in-java
- https://developer.android.com/jetpack/androidx/releases/fragment#1.5.0-alpha05