### PR TITLE
Bump AS from Flamingo to Girafee

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can develop this project.
 
 ### Environment
 
-- Android Studio: Flamingo | 2022.2.1 Patch 2
+- Android Studio: Giraffe | 2022.3.1
 
 ### Configuration
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version = "4.10
 timber = { group = "com.jakewharton.timber", name = "timber", version = "5.0.1" }
 
 [plugins]
-android-application = { id = "com.android.application", version = "8.0.2" }
+android-application = { id = "com.android.application", version = "8.1.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.17.0" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "2.9.4" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version = "1.4.2" }


### PR DESCRIPTION
## Overview

- Bump AS from Flamingo to Girafee
- Bump AGP from 8.0.2 to 8.1.0

## Checklist

- [x] Format code (<kbd>⌥⌘L</kbd> in Android Studio)
- [x] Optimize imports (<kbd>^⌥O</kbd> in Android Studio)
- [ ] Resolve Android Studio warning

## References

### Overall

- #266